### PR TITLE
Fix grammar mistake in cr-cnr.html

### DIFF
--- a/cr-cnr.html
+++ b/cr-cnr.html
@@ -48,7 +48,7 @@
 				<h3>Add a can or can't reproduce to an existing bug report.</h3>
 			</div>
 			<div class="form-group">
-				<label for="canCantOption">Choose wether or not you can reproduce the bug.</label>
+				<label for="canCantOption">Choose whether or not you can reproduce the bug.</label>
 				<select class="form-control" id="canCantOption">
 					<option value="canrepro" selected>Can Reproduce</option>
 					<option value="cantrepro">Can't Reproduce</option>


### PR DESCRIPTION
The previous version was using the male lamb instead of 'whether'.